### PR TITLE
Update 'curb' version in Gemfile to 0.8.8 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    curb (0.8.5)
+    curb (0.8.8)
     diff-lcs (1.2.5)
     rack (1.5.2)
     rack-protection (1.5.3)


### PR DESCRIPTION
Based on [this ISSUE](https://github.com/taf2/curb/issues/234) of `curb` gem, version `0.8.5` cannot be installed on some OS distributions (e.g CentOS 7). But the problem is fixed in version `0.8.8`