### PR TITLE
Add $repsheet, $repsheet_reason, store request state on request ctx

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,6 @@ http {
 
   proxy_set_header X-Repsheet $repsheet;
 
-  map '_' $repsheet {
-    default 'false';
-  }
-
   server {
     listen 8888;
     location / {
@@ -96,12 +92,10 @@ http {
 }
 ```
 
-Notice the additional `proxy_set_header` and following `map`
-directives. These are placed in the configuration when applying
-marking. The module will populate the `$repsheet` variable when a mark
-needs to be applied, but the variable has to exist before it can be set.
-This ensures that the variable exists across the entirety of
-your configuration.
+Notice the `proxy_set_header` directive. This is placed in the configuration
+when applying marking. The module will populate the `$repsheet` variable when a mark
+needs to be applied, and it will also populate the `$repsheet_reason` variable with
+the reason for the marking.
 
 ## Running the Integration Tests
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,10 +23,6 @@ http {
 
   proxy_set_header X-Repsheet $repsheet;
 
-  map '_' $repsheet {
-    default 'false';
-  }
-
   upstream app {
     server localhost:4567;
   }


### PR DESCRIPTION
This change removes the need to pre-set any variables in the nginx configuration by updating the module to provide both the `$repsheet` and `$repsheet_reason` variables. Due to how the proxy module works, setting `proxy_set_header X-Repsheet $repsheet;` is still required for passing the marking header to any upstream proxies.

I also updated the module to properly store it's state on the module's request context (instead of on the location config which is shared between requests), and I removed the guard that prevented the module from running for internal redirects (these subrequests cause a request to clear its state).

It doesn't look like there are any tests that test to ensure the variables set by this module (essentially the marking headers) are set/proxied correctly -- is that intentional?